### PR TITLE
Use Array.Hamt

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -10,6 +10,7 @@
         "Diff"
     ],
     "dependencies": {
+        "Skinney/elm-array-exploration": "2.0.5 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"

--- a/src/Diff.elm
+++ b/src/Diff.elm
@@ -12,7 +12,7 @@ Each function internally uses Wu's [O(NP) algorithm](http://myerslab.mpi-cbg.de/
 -}
 
 
-import Array exposing (Array)
+import Array.Hamt as Array exposing (Array)
 
 
 {-| This describes how each line has changed and also contains its value.


### PR DESCRIPTION
[`Skinney/elm-array-exploration`](http://package.elm-lang.org/packages/Skinney/elm-array-exploration/latest) has equivalent performance and a bunch of bugfixes compared to the `Array` in current `core`.

This switches to use it!