### PR TITLE
remove Result.andThen in makeChangesHelp

### DIFF
--- a/src/Diff.elm
+++ b/src/Diff.elm
@@ -174,12 +174,12 @@ makeChangesHelp changes getA getB ( x, y ) path =
                     else
                         Err (UnexpectedPath ( x, y ) path)
             in
-            change
-                |> Result.andThen
-                    (\c ->
-                        makeChangesHelp (c :: changes) getA getB ( prevX, prevY ) tail
-                    )
+            case change of
+                Ok c ->
+                    makeChangesHelp (c :: changes) getA getB ( prevX, prevY ) tail
 
+                Err e ->
+                    Err e
 
 
 -- Myers's O(ND) algorithm (http://www.xmailserver.org/diff2.pdf)


### PR DESCRIPTION
It was defeating tail call recursion, so very long diffs would overflow.

Simplest failing test case I found, but didn't add to the library:

```elm
diff
    (List.repeat 1000 "a") -- really it was like 780 but 1000 is a nicer round number :)
    []
```